### PR TITLE
update for document_root installations

### DIFF
--- a/etc/class/cya.php
+++ b/etc/class/cya.php
@@ -1,7 +1,12 @@
 <?php
 set_include_path(__DIR__ . ':' . __DIR__ . '/banks');
 
-define('INSTALL_PATH', dirname(dirname(substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT'])))));
+$install_path = dirname(dirname(substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT']))));
+
+if ($install_path == '/') {
+	$install_path = '';
+}
+define('INSTALL_PATH', $install_path);
 
 ini_set('default_charset', 'UTF-8');
 mb_internal_encoding('UTF-8');
@@ -31,7 +36,7 @@ function IsSetup() {
 }
 
 function GoSetup() {
-  header('Location: ' . $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . dirname(dirname(substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT'])))) . '/setup.php');
+  header('Location: /setup.php');
   die;
 }
 


### PR DESCRIPTION
INSTALL_PATH set to empty string instead of /,

location redirects to a root-relative page instead of a full url due to not all apache’s populating the Request_scheme key